### PR TITLE
Bug: Else-statements do not compile

### DIFF
--- a/src/backend/compiler.zig
+++ b/src/backend/compiler.zig
@@ -226,25 +226,35 @@ fn conditional(self: *Compiler, target: *Ast.Conditional) Errors!u8 {
     }
     try out.writeAll(&.{ @intFromEnum(OpCodes.jump_neq), cmp });
     try out.writeInt(u16, 0, .big);
-    // Compile bytecode to jump over the 'then' body
+    // Get current ip to patch the jump dst later
     const current_ip = frame.instructions.items.len - 1;
+    // var else_ip: usize = 0;
+
+    // Compile the body
     const body = try self.statement(target.body);
+    // Handle jump instruction for otherwise instructions.
+    // If body doesn't exist, let IP over into the next code
+    if (target.otherwise != null) {
+        try out.writeByte(@intFromEnum(OpCodes.jump));
+        try out.writeInt(u16, 0, .big);
+    }
+    const body_ip = frame.instructions.items.len - 1;
+    // Patch bytecode to include new jump target if else-block exists
+    defer if (target.otherwise != null) {
+        const target_ip = frame.instructions.items.len;
+        frame.instructions.items[body_ip - 1] = @truncate((target_ip & 0xff00) >> 8);
+        frame.instructions.items[body_ip] = @truncate(target_ip);
+    };
+
     const target_ip = frame.instructions.items.len;
     // Patch the bytecode with the new target to jump to
     frame.instructions.items[current_ip - 1] = @truncate((target_ip & 0xff00) >> 8);
     frame.instructions.items[current_ip] = @truncate(target_ip);
 
-    // TODO: Implement else for if-statements
-    // if (target.otherwise) |else_blk| {
-    //     if (self.instructions.items.len > std.math.maxInt(u16)) {
-    //         try self.reportError("Invalid jump target");
-    //         return Error.InvalidJmpTarget;
-    //     }
-    //     const else_ip: u16 = @truncate(self.instructions.items.len + 3);
-    //     try out.writeByte(@intFromEnum(opcodes.jump));
-    //     try out.writeInt(u16, else_ip);
-    //     _ = try self.statement(else_blk);
-    // }
+    // Compile the else-block
+    if (target.otherwise) |else_blk| {
+        _ = try self.statement(else_blk);
+    }
 
     return body;
 }

--- a/src/frontend/lexer.zig
+++ b/src/frontend/lexer.zig
@@ -267,6 +267,7 @@ pub const keywords = std.StaticStringMap(TokenType).initComptime(&.{
     &.{ "self", .obj_self },
     &.{ "new", .new_obj },
     &.{ "if", .if_stmt },
+    &.{ "else", .else_stmt },
     &.{ "while", .while_stmt },
     &.{ "for", .for_stmt },
     &.{ "return", .@"return" },

--- a/src/frontend/lexer.zig
+++ b/src/frontend/lexer.zig
@@ -305,14 +305,24 @@ fn makeToken(self: *Lexer, tokenType: TokenType, start: u64) TokenData {
 }
 
 pub fn getLineSource(self: *Lexer, info: TokenInfo) []const u8 {
-    var current = info.line - 1;
+    var line: usize = 0;
+    var current: usize = 0;
+    var c = self.buf[current];
+    const startPos = while (true) : (c = self.buf[current]) {
+        current += 1;
+        if (current == self.buf.len) break current;
+        if (c == '\n') {
+            line += 1;
+            continue;
+        }
+        if (line == info.line - 1) break current;
+    };
     // If next line is just an empty line, return empty string
     if (current >= self.buf.len) return "";
-    var c = self.buf[current];
     const endPos = while (true) : (c = self.buf[current]) {
         current += 1;
         if (c == '\n' or current == self.buf.len) break current;
     };
 
-    return self.buf[info.line - 1 .. endPos];
+    return self.buf[startPos..endPos];
 }

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -314,6 +314,7 @@ pub fn run(self: *Vm) !void {
         },
         .jump_neq => {
             const isEql = try self.nextReg();
+            log.debug("Is eql: {}", .{try Value.asBool(isEql)});
             const ip = self.readInt(u16);
             if (!(try Value.asBool(isEql))) {
                 self.current().ip = ip;

--- a/src/runtime/vm.zig
+++ b/src/runtime/vm.zig
@@ -314,7 +314,6 @@ pub fn run(self: *Vm) !void {
         },
         .jump_neq => {
             const isEql = try self.nextReg();
-            log.debug("Is eql: {}", .{try Value.asBool(isEql)});
             const ip = self.readInt(u16);
             if (!(try Value.asBool(isEql))) {
                 self.current().ip = ip;


### PR DESCRIPTION
This fixes the issue where else-statements do not compile (and raises the issue as "Expected ';' after expression").

Also fixed an issue where the lexer only looks at the first line in the source code.
Now the `getLineSource` function figures out the start position by iterating until the correct line is found.